### PR TITLE
Add Finance category with FreeFile ITR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ What is local first?
 ### Social Networks
 
 - [Secure Scuttlebutt](https://scuttlebutt.nz/) - a peer-to peer communication protocol, mesh network, and self-hosted social media ecosystem
+
+### Finance
+
+- [FreeFile ITR](https://github.com/rohitthink/freefile) - A privacy-first income tax return filing app for Indian freelancers. Imports bank statements, computes tax under both old and new regimes, and files directly on incometax.gov.in. All financial data is stored locally on the user's device using SQLite. Built with Next.js, FastAPI, and Tauri. Licensed under AGPL-3.0.


### PR DESCRIPTION
## Addition

Adding a new **Finance** section under Applications, with FreeFile ITR as the first entry.

**Project:** https://github.com/rohitthink/freefile
**License:** AGPL-3.0

## Why it's local-first

FreeFile ITR is a local-first income tax return filing app for Indian freelancers. It aligns tightly with the local-first principles from Ink & Switch:

1. **No spinners — user owns their data:** All financial data stored locally in SQLite. No backend database. App works fully offline.
2. **Works on multiple devices:** Desktop (Tauri), mobile (Capacitor Android/iOS), and web (FastAPI + Next.js).
3. **Network is optional:** The only network calls are (a) optional cloud PDF parsing for encrypted bank statements, and (b) browser-driven filing on the official tax portal via Playwright. Core app functionality (categorization, tax computation, reports) runs entirely offline.
4. **Long-term usability:** Open source under AGPL-3.0, so the app remains usable even if the original maintainer disappears.
5. **Privacy & security by default:** No accounts, no telemetry, no data leaves the device.

## Tech stack

- **Backend:** Python FastAPI + SQLite (aiosqlite)
- **Frontend:** Next.js + React + TypeScript
- **Desktop:** Tauri 2
- **Mobile:** Capacitor 8

Thanks for maintaining this list!