### PR TITLE
Add Ano under Team Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ What is local first?
 ### Social Networks
 
 - [Secure Scuttlebutt](https://scuttlebutt.nz/) - a peer-to peer communication protocol, mesh network, and self-hosted social media ecosystem
+
+### Team Collaboration
+
+- [Ano](https://ano.chat/) - A collaborative, local-first team chat powered by Rocicorp's Zero sync engine and Postgres. Features sub-millisecond channel switching, instant multi-device sync, and zero-latency responsiveness.


### PR DESCRIPTION
Added [Ano](https://ano.chat/) under a new Team Collaboration category. It is a high-performance Slack alternative built entirely on Zero and Postgres.